### PR TITLE
Verbose mode uses query string as printf format.

### DIFF
--- a/mysql-sniffer.go
+++ b/mysql-sniffer.go
@@ -221,7 +221,7 @@ func handleQuery(query []byte, dirty bool, verbose bool) {
 
 	// if verbose, just print it
 	if verbose {
-		log.Printf("%s", qstr)
+		log.Print(qstr)
 		return
 	}
 


### PR DESCRIPTION
Do not use the query string itself as the printf format for verbose mode.

This is mainly an issue with unsanitized mode and ends up outputting things like `select "%s(MISSING)"`

( I apologize if you didn't want someone playing with this that much, but it was bugging me, and since _I_ fixed it, I figured I should be a Good Open Source Software User™ )
