### PR TITLE
Update for Go version 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-include $(GOROOT)/src/Make.inc
-
-TARG=mysql-sniffer
-CLEANFILES=mysql-sniffer
-
-mysql-sniffer: mysql-sniffer.go
-	$(GC) mysql-sniffer.go
-	$(LD) -o $@ mysql-sniffer.$(O)

--- a/README
+++ b/README
@@ -12,7 +12,7 @@ There are other options useful for tuning the output to your specifications.
 Please see the application help and play with it.
 
 To compile, you need the Go compiler (http://golang.org) as well as the gopcap
-library (https://github.com/xb95/gopcap) compiled and installed where 6g/6l
+library (https://github.com/akrennmair/gopcap) compiled and installed where go
 can find it.
 
 Written by Mark Smith <mark@qq.is>.

--- a/mysql-sniffer.go
+++ b/mysql-sniffer.go
@@ -14,7 +14,7 @@
  * written by Mark Smith <mark@qq.is>
  *
  * requires the gopcap library to be installed from:
- *   https://github.com/xb95/gopcap
+ *   https://github.com/akrennmair/gopcap
  *
  */
 
@@ -30,13 +30,17 @@ import (
 	"time"
 )
 
-var start int64 = time.Seconds()
+var start int64 = UnixNow()
 var qbuf map[string]int = make(map[string]int)
 var querycount int
 
 const TOKEN_DEFAULT = 0
 const TOKEN_QUOTE = 1
 const TOKEN_NUMBER = 2
+
+func UnixNow() int64 {
+	return time.Now().Unix()
+}
 
 func main() {
 	var port *int = flag.Int("P", 3306, "MySQL port to use")
@@ -66,7 +70,7 @@ func main() {
 		log.Fatalf("Failed to set port filter: %s", err)
 	}
 
-	last := time.Seconds()
+	last := UnixNow()
 	var pkt *pcap.Packet = nil
 	var rv int32 = 0
 
@@ -77,8 +81,8 @@ func main() {
 			// simple output printer... this should be super fast since we expect that a
 			// system like this will have relatively few unique queries once they're
 			// canonicalized.
-			if !*verbose && querycount%100 == 0 && last < time.Seconds()-int64(*period) {
-				last = time.Seconds()
+			if !*verbose && querycount%100 == 0 && last < UnixNow()-int64(*period) {
+				last = UnixNow()
 				handleStatusUpdate(*displaycount)
 			}
 		}
@@ -86,7 +90,7 @@ func main() {
 }
 
 func handleStatusUpdate(displaycount int) {
-	elapsed := float64(time.Seconds() - start)
+	elapsed := float64(UnixNow() - start)
 
 	// print status bar
 	log.Printf("\n")


### PR DESCRIPTION
Uses upstream version of gopcap ( https://github.com/akrennmair/gopcap ) instead of your fork as your changes have been merged in, as well as your version doesn't have the Go version 1 fixes.

time.Seconds() no longer exists, use more verbose version.
